### PR TITLE
chore: add repo and homepage urls to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.2"
 authors = ["Kacy Fortner <kacy@kacyfortner.com>"]
 edition = "2021"
 description = "Rust client for Supabase"
+repository = "https://github.com/kacy/supabase-rust.git"
+homepage = "https://github.com/kacy/supabase-rust"
 license = "MIT"
 
 [dev-dependencies]


### PR DESCRIPTION
This will help people to navigate from docs.rs and crates.io to the project repo.

The newline at the end of the file was automatically added by the GH editor, but I agree with that change. :)