### PR TITLE
Refactor codebase for idiomatic Rust

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,30 +1,33 @@
-use std::{env};
-use reqwest::{Client};
+use std::env;
+
+use reqwest::Client;
 
 use crate::Supabase;
 
 impl Supabase {
-    // Creates a new Supabase client. If no parameters are provided, it will attempt to read the
-    // environment variables `SUPABASE_URL`, `SUPABASE_API_KEY`, and `SUPABASE_JWT_SECRET`.
+    /// Creates a new Supabase client.
+    ///
+    /// If no parameters are provided, it will attempt to read from environment
+    /// variables: `SUPABASE_URL`, `SUPABASE_API_KEY`, and `SUPABASE_JWT_SECRET`.
     pub fn new(url: Option<&str>, api_key: Option<&str>, jwt: Option<&str>) -> Self {
-        let client: Client = Client::new();
-        let url: String = url
-            .map(String::from)
-            .unwrap_or_else(|| env::var("SUPABASE_URL").unwrap_or_else(|_| String::new()));
-        let api_key: String = api_key
-            .map(String::from)
-            .unwrap_or_else(|| env::var("SUPABASE_API_KEY").unwrap_or_else(|_| String::new()));
-        let jwt: String = jwt
-            .map(String::from)
-            .unwrap_or_else(|| env::var("SUPABASE_JWT_SECRET").unwrap_or_else(|_| String::new()));
-
-        Supabase {
-            client,
-            url: url.to_string(),
-            api_key: api_key.to_string(),
-            jwt: jwt.to_string(),
+        Self {
+            client: Client::new(),
+            url: url
+                .map(Into::into)
+                .unwrap_or_else(|| env::var("SUPABASE_URL").unwrap_or_default()),
+            api_key: api_key
+                .map(Into::into)
+                .unwrap_or_else(|| env::var("SUPABASE_API_KEY").unwrap_or_default()),
+            jwt: jwt
+                .map(Into::into)
+                .unwrap_or_else(|| env::var("SUPABASE_JWT_SECRET").unwrap_or_default()),
             bearer_token: None,
         }
+    }
+
+    /// Sets the bearer token for authenticated requests.
+    pub fn set_bearer_token(&mut self, token: impl Into<String>) {
+        self.bearer_token = Some(token.into());
     }
 }
 
@@ -33,9 +36,28 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_client() {
-        let client: Supabase = Supabase::new(None, None, None);
-        let url = client.url.clone();
-        assert!(client.url == url);
+    fn test_client_creation() {
+        let client = Supabase::new(
+            Some("https://example.supabase.co"),
+            Some("test-key"),
+            Some("test-jwt"),
+        );
+        assert_eq!(client.url, "https://example.supabase.co");
+        assert_eq!(client.api_key, "test-key");
+        assert_eq!(client.jwt, "test-jwt");
+    }
+
+    #[test]
+    fn test_client_from_env() {
+        // When env vars are not set, fields should be empty
+        let client = Supabase::new(None, None, None);
+        assert!(client.bearer_token.is_none());
+    }
+
+    #[test]
+    fn test_set_bearer_token() {
+        let mut client = Supabase::new(None, None, None);
+        client.set_bearer_token("my-token");
+        assert_eq!(client.bearer_token, Some("my-token".to_string()));
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -3,7 +3,47 @@ use serde::Serialize;
 
 use crate::Supabase;
 
+/// Error type for database operations.
+#[derive(Debug)]
+pub enum DbError {
+    /// Failed to serialize data to JSON.
+    Serialization(serde_json::Error),
+    /// HTTP request failed.
+    Request(Error),
+}
+
+impl std::fmt::Display for DbError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Serialization(e) => write!(f, "serialization error: {e}"),
+            Self::Request(e) => write!(f, "request error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for DbError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Serialization(e) => Some(e),
+            Self::Request(e) => Some(e),
+        }
+    }
+}
+
+impl From<serde_json::Error> for DbError {
+    fn from(err: serde_json::Error) -> Self {
+        Self::Serialization(err)
+    }
+}
+
+impl From<Error> for DbError {
+    fn from(err: Error) -> Self {
+        Self::Request(err)
+    }
+}
+
 /// Query builder for PostgREST database operations.
+///
 /// Provides a fluent API for constructing and executing database queries.
 pub struct QueryBuilder<'a> {
     client: &'a Supabase,
@@ -15,10 +55,10 @@ pub struct QueryBuilder<'a> {
 
 impl<'a> QueryBuilder<'a> {
     /// Creates a new QueryBuilder for the specified table.
-    pub fn new(client: &'a Supabase, table: &str) -> Self {
-        QueryBuilder {
+    pub(crate) fn new(client: &'a Supabase, table: impl Into<String>) -> Self {
+        Self {
             client,
-            table: table.to_string(),
+            table: table.into(),
             query_params: Vec::new(),
             method: Method::GET,
             body: None,
@@ -26,155 +66,169 @@ impl<'a> QueryBuilder<'a> {
     }
 
     /// Specifies which columns to select.
-    /// Pass "*" to select all columns, or a comma-separated list of column names.
-    pub fn select(mut self, columns: &str) -> Self {
-        self.query_params.push(("select".to_string(), columns.to_string()));
+    ///
+    /// Pass `"*"` to select all columns, or a comma-separated list of column names.
+    pub fn select(mut self, columns: impl Into<String>) -> Self {
+        self.query_params.push(("select".into(), columns.into()));
         self.method = Method::GET;
         self
     }
 
     /// Prepares an insert operation with the provided data.
-    /// Data will be serialized to JSON.
-    pub fn insert<T: Serialize>(mut self, data: &T) -> Self {
+    ///
+    /// Data will be serialized to JSON. Call `execute()` to run the query.
+    pub fn insert<T: Serialize>(mut self, data: &T) -> Result<Self, serde_json::Error> {
         self.method = Method::POST;
-        self.body = Some(serde_json::to_string(data).unwrap());
-        self
+        self.body = Some(serde_json::to_string(data)?);
+        Ok(self)
     }
 
     /// Prepares an update operation with the provided data.
+    ///
     /// Should be combined with filter methods to target specific rows.
-    pub fn update<T: Serialize>(mut self, data: &T) -> Self {
+    pub fn update<T: Serialize>(mut self, data: &T) -> Result<Self, serde_json::Error> {
         self.method = Method::PATCH;
-        self.body = Some(serde_json::to_string(data).unwrap());
-        self
+        self.body = Some(serde_json::to_string(data)?);
+        Ok(self)
     }
 
     /// Prepares a delete operation.
+    ///
     /// Should be combined with filter methods to target specific rows.
     pub fn delete(mut self) -> Self {
         self.method = Method::DELETE;
         self
     }
 
-    /// Filter: column equals value (col=eq.val)
-    pub fn eq(mut self, column: &str, value: &str) -> Self {
-        self.query_params.push((column.to_string(), format!("eq.{}", value)));
+    /// Filter: column equals value (`col=eq.val`).
+    pub fn eq(self, column: impl Into<String>, value: impl Into<String>) -> Self {
+        self.add_filter(column, "eq", value)
+    }
+
+    /// Filter: column not equals value (`col=neq.val`).
+    pub fn neq(self, column: impl Into<String>, value: impl Into<String>) -> Self {
+        self.add_filter(column, "neq", value)
+    }
+
+    /// Filter: column greater than value (`col=gt.val`).
+    pub fn gt(self, column: impl Into<String>, value: impl Into<String>) -> Self {
+        self.add_filter(column, "gt", value)
+    }
+
+    /// Filter: column greater than or equal to value (`col=gte.val`).
+    pub fn gte(self, column: impl Into<String>, value: impl Into<String>) -> Self {
+        self.add_filter(column, "gte", value)
+    }
+
+    /// Filter: column less than value (`col=lt.val`).
+    pub fn lt(self, column: impl Into<String>, value: impl Into<String>) -> Self {
+        self.add_filter(column, "lt", value)
+    }
+
+    /// Filter: column less than or equal to value (`col=lte.val`).
+    pub fn lte(self, column: impl Into<String>, value: impl Into<String>) -> Self {
+        self.add_filter(column, "lte", value)
+    }
+
+    /// Filter: column matches pattern (`col=like.pattern`).
+    ///
+    /// Use `*` as wildcard character.
+    pub fn like(self, column: impl Into<String>, pattern: impl Into<String>) -> Self {
+        self.add_filter(column, "like", pattern)
+    }
+
+    /// Filter: column matches pattern case-insensitively (`col=ilike.pattern`).
+    ///
+    /// Use `*` as wildcard character.
+    pub fn ilike(self, column: impl Into<String>, pattern: impl Into<String>) -> Self {
+        self.add_filter(column, "ilike", pattern)
+    }
+
+    /// Filter: column value is in the provided list (`col=in.(v1,v2,...)`).
+    pub fn in_<I, S>(mut self, column: impl Into<String>, values: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let values_str: Vec<_> = values.into_iter().map(|s| s.as_ref().to_string()).collect();
+        self.query_params
+            .push((column.into(), format!("in.({})", values_str.join(","))));
         self
     }
 
-    /// Filter: column not equals value (col=neq.val)
-    pub fn neq(mut self, column: &str, value: &str) -> Self {
-        self.query_params.push((column.to_string(), format!("neq.{}", value)));
+    /// Filter: column is null (`col=is.null`).
+    pub fn is_null(mut self, column: impl Into<String>) -> Self {
+        self.query_params.push((column.into(), "is.null".into()));
         self
     }
 
-    /// Filter: column greater than value (col=gt.val)
-    pub fn gt(mut self, column: &str, value: &str) -> Self {
-        self.query_params.push((column.to_string(), format!("gt.{}", value)));
-        self
-    }
-
-    /// Filter: column greater than or equal to value (col=gte.val)
-    pub fn gte(mut self, column: &str, value: &str) -> Self {
-        self.query_params.push((column.to_string(), format!("gte.{}", value)));
-        self
-    }
-
-    /// Filter: column less than value (col=lt.val)
-    pub fn lt(mut self, column: &str, value: &str) -> Self {
-        self.query_params.push((column.to_string(), format!("lt.{}", value)));
-        self
-    }
-
-    /// Filter: column less than or equal to value (col=lte.val)
-    pub fn lte(mut self, column: &str, value: &str) -> Self {
-        self.query_params.push((column.to_string(), format!("lte.{}", value)));
-        self
-    }
-
-    /// Filter: column matches pattern (col=like.pattern)
-    /// Use * as wildcard character.
-    pub fn like(mut self, column: &str, pattern: &str) -> Self {
-        self.query_params.push((column.to_string(), format!("like.{}", pattern)));
-        self
-    }
-
-    /// Filter: column matches pattern case-insensitively (col=ilike.pattern)
-    /// Use * as wildcard character.
-    pub fn ilike(mut self, column: &str, pattern: &str) -> Self {
-        self.query_params.push((column.to_string(), format!("ilike.{}", pattern)));
-        self
-    }
-
-    /// Filter: column value is in the provided list (col=in.(v1,v2,...))
-    pub fn in_(mut self, column: &str, values: &[&str]) -> Self {
-        let values_str = values.join(",");
-        self.query_params.push((column.to_string(), format!("in.({})", values_str)));
-        self
-    }
-
-    /// Filter: column is null (col=is.null)
-    pub fn is_null(mut self, column: &str) -> Self {
-        self.query_params.push((column.to_string(), "is.null".to_string()));
-        self
-    }
-
-    /// Filter: column is not null (col=not.is.null)
-    pub fn not_null(mut self, column: &str) -> Self {
-        self.query_params.push((column.to_string(), "not.is.null".to_string()));
+    /// Filter: column is not null (`col=not.is.null`).
+    pub fn not_null(mut self, column: impl Into<String>) -> Self {
+        self.query_params.push((column.into(), "not.is.null".into()));
         self
     }
 
     /// Orders results by the specified column.
-    /// Use "column" for ascending or "column.desc" for descending.
-    pub fn order(mut self, column: &str) -> Self {
-        self.query_params.push(("order".to_string(), column.to_string()));
+    ///
+    /// Use `"column"` for ascending or `"column.desc"` for descending.
+    pub fn order(mut self, column: impl Into<String>) -> Self {
+        self.query_params.push(("order".into(), column.into()));
         self
     }
 
     /// Limits the number of rows returned.
     pub fn limit(mut self, count: usize) -> Self {
-        self.query_params.push(("limit".to_string(), count.to_string()));
+        self.query_params.push(("limit".into(), count.to_string()));
         self
     }
 
     /// Offsets the results by the specified number of rows.
     pub fn offset(mut self, count: usize) -> Self {
-        self.query_params.push(("offset".to_string(), count.to_string()));
+        self.query_params.push(("offset".into(), count.to_string()));
         self
     }
 
     /// Executes the query and returns the response.
     pub async fn execute(self) -> Result<Response, Error> {
-        let request_url = format!("{}/rest/v1/{}", self.client.url, self.table);
+        let url = format!("{}/rest/v1/{}", self.client.url, self.table);
 
-        let mut request = self.client.client.request(self.method, &request_url);
+        let mut request = self
+            .client
+            .client
+            .request(self.method, &url)
+            .header("apikey", &self.client.api_key)
+            .header("Content-Type", "application/json");
 
-        // Add standard headers
-        request = request.header("apikey", &self.client.api_key);
-        request = request.header("Content-Type", "application/json");
-
-        // Add bearer token if available
         if let Some(ref token) = self.client.bearer_token {
             request = request.bearer_auth(token);
         }
 
-        // Add query parameters
         if !self.query_params.is_empty() {
             request = request.query(&self.query_params);
         }
 
-        // Add body if present
         if let Some(body) = self.body {
             request = request.body(body);
         }
 
         request.send().await
     }
+
+    fn add_filter(
+        mut self,
+        column: impl Into<String>,
+        op: &str,
+        value: impl Into<String>,
+    ) -> Self {
+        self.query_params
+            .push((column.into(), format!("{op}.{}", value.into())));
+        self
+    }
 }
 
 impl Supabase {
     /// Creates a QueryBuilder for the specified table.
+    ///
     /// This is the entry point for all database operations.
     ///
     /// # Examples
@@ -187,15 +241,15 @@ impl Supabase {
     /// client.from("users").select("id,name").eq("status", "active").execute().await?;
     ///
     /// // Insert
-    /// client.from("users").insert(&user_data).execute().await?;
+    /// client.from("users").insert(&user_data)?.execute().await?;
     ///
     /// // Update
-    /// client.from("users").update(&updates).eq("id", "123").execute().await?;
+    /// client.from("users").update(&updates)?.eq("id", "123").execute().await?;
     ///
     /// // Delete
     /// client.from("users").delete().eq("id", "123").execute().await?;
     /// ```
-    pub fn from(&self, table: &str) -> QueryBuilder {
+    pub fn from(&self, table: impl Into<String>) -> QueryBuilder {
         QueryBuilder::new(self, table)
     }
 }
@@ -205,7 +259,7 @@ mod tests {
     use super::*;
     use serde::{Deserialize, Serialize};
 
-    async fn client() -> Supabase {
+    fn client() -> Supabase {
         Supabase::new(None, None, None)
     }
 
@@ -215,166 +269,141 @@ mod tests {
         value: i32,
     }
 
-    #[derive(Debug, Serialize, Deserialize)]
-    struct TestItemWithId {
-        id: i64,
-        name: String,
-        value: i32,
-    }
-
     #[tokio::test]
     async fn test_select() {
-        let client = client().await;
+        let client = client();
 
-        // This test requires a 'test_items' table in Supabase
-        let response = client
-            .from("test_items")
-            .select("*")
-            .execute()
-            .await;
+        let result = client.from("test_items").select("*").execute().await;
 
-        match response {
+        match result {
             Ok(resp) => {
-                // If we get a response, check status (might be 200 or 401 depending on auth)
                 let status = resp.status();
-                println!("Select response status: {}", status);
                 assert!(status.is_success() || status.as_u16() == 401);
             }
             Err(e) => {
-                // Network error is acceptable in test environment
-                println!("Select test skipped due to network error: {}", e);
+                println!("Test skipped due to network error: {e}");
             }
         }
     }
 
     #[tokio::test]
     async fn test_select_columns() {
-        let client = client().await;
+        let client = client();
 
-        let response = client
-            .from("test_items")
-            .select("id,name")
-            .execute()
-            .await;
+        let result = client.from("test_items").select("id,name").execute().await;
 
-        match response {
+        match result {
             Ok(resp) => {
                 let status = resp.status();
-                println!("Select columns response status: {}", status);
                 assert!(status.is_success() || status.as_u16() == 401);
             }
             Err(e) => {
-                println!("Select columns test skipped due to network error: {}", e);
+                println!("Test skipped due to network error: {e}");
             }
         }
     }
 
     #[tokio::test]
     async fn test_select_with_filter() {
-        let client = client().await;
+        let client = client();
 
-        let response = client
+        let result = client
             .from("test_items")
             .select("*")
             .eq("name", "test")
             .execute()
             .await;
 
-        match response {
+        match result {
             Ok(resp) => {
                 let status = resp.status();
-                println!("Select with filter response status: {}", status);
                 assert!(status.is_success() || status.as_u16() == 401);
             }
             Err(e) => {
-                println!("Select with filter test skipped due to network error: {}", e);
+                println!("Test skipped due to network error: {e}");
             }
         }
     }
 
     #[tokio::test]
     async fn test_insert() {
-        let client = client().await;
+        let client = client();
 
         let item = TestItem {
-            name: "test_item".to_string(),
+            name: "test_item".into(),
             value: 42,
         };
 
-        let response = client
+        let result = client
             .from("test_items")
             .insert(&item)
+            .expect("serialization should succeed")
             .execute()
             .await;
 
-        match response {
+        match result {
             Ok(resp) => {
                 let status = resp.status();
-                println!("Insert response status: {}", status);
-                // 201 Created, 200 OK, or 401 Unauthorized (if auth required)
                 assert!(status.is_success() || status.as_u16() == 401);
             }
             Err(e) => {
-                println!("Insert test skipped due to network error: {}", e);
+                println!("Test skipped due to network error: {e}");
             }
         }
     }
 
     #[tokio::test]
     async fn test_update() {
-        let client = client().await;
+        let client = client();
 
-        let updates = serde_json::json!({
-            "value": 100
-        });
+        let updates = serde_json::json!({ "value": 100 });
 
-        let response = client
+        let result = client
             .from("test_items")
             .update(&updates)
+            .expect("serialization should succeed")
             .eq("name", "test_item")
             .execute()
             .await;
 
-        match response {
+        match result {
             Ok(resp) => {
                 let status = resp.status();
-                println!("Update response status: {}", status);
                 assert!(status.is_success() || status.as_u16() == 401);
             }
             Err(e) => {
-                println!("Update test skipped due to network error: {}", e);
+                println!("Test skipped due to network error: {e}");
             }
         }
     }
 
     #[tokio::test]
     async fn test_delete() {
-        let client = client().await;
+        let client = client();
 
-        let response = client
+        let result = client
             .from("test_items")
             .delete()
             .eq("name", "test_item")
             .execute()
             .await;
 
-        match response {
+        match result {
             Ok(resp) => {
                 let status = resp.status();
-                println!("Delete response status: {}", status);
                 assert!(status.is_success() || status.as_u16() == 401);
             }
             Err(e) => {
-                println!("Delete test skipped due to network error: {}", e);
+                println!("Test skipped due to network error: {e}");
             }
         }
     }
 
     #[tokio::test]
     async fn test_select_with_order_and_limit() {
-        let client = client().await;
+        let client = client();
 
-        let response = client
+        let result = client
             .from("test_items")
             .select("*")
             .order("id.desc")
@@ -382,23 +411,22 @@ mod tests {
             .execute()
             .await;
 
-        match response {
+        match result {
             Ok(resp) => {
                 let status = resp.status();
-                println!("Select with order/limit response status: {}", status);
                 assert!(status.is_success() || status.as_u16() == 401);
             }
             Err(e) => {
-                println!("Select with order/limit test skipped due to network error: {}", e);
+                println!("Test skipped due to network error: {e}");
             }
         }
     }
 
     #[tokio::test]
     async fn test_select_with_multiple_filters() {
-        let client = client().await;
+        let client = client();
 
-        let response = client
+        let result = client
             .from("test_items")
             .select("*")
             .gte("value", "10")
@@ -406,38 +434,44 @@ mod tests {
             .execute()
             .await;
 
-        match response {
+        match result {
             Ok(resp) => {
                 let status = resp.status();
-                println!("Select with multiple filters response status: {}", status);
                 assert!(status.is_success() || status.as_u16() == 401);
             }
             Err(e) => {
-                println!("Select with multiple filters test skipped due to network error: {}", e);
+                println!("Test skipped due to network error: {e}");
             }
         }
     }
 
     #[tokio::test]
     async fn test_in_filter() {
-        let client = client().await;
+        let client = client();
 
-        let response = client
+        let result = client
             .from("test_items")
             .select("*")
-            .in_("id", &["1", "2", "3"])
+            .in_("id", ["1", "2", "3"])
             .execute()
             .await;
 
-        match response {
+        match result {
             Ok(resp) => {
                 let status = resp.status();
-                println!("Select with in filter response status: {}", status);
                 assert!(status.is_success() || status.as_u16() == 401);
             }
             Err(e) => {
-                println!("Select with in filter test skipped due to network error: {}", e);
+                println!("Test skipped due to network error: {e}");
             }
         }
+    }
+
+    #[test]
+    fn test_db_error_display() {
+        // Verify error types display correctly
+        let json_err = serde_json::from_str::<i32>("invalid").unwrap_err();
+        let db_err = DbError::Serialization(json_err);
+        assert!(format!("{db_err}").contains("serialization error"));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-use reqwest::{Client};
+use reqwest::Client;
 
 pub mod auth;
 mod client;


### PR DESCRIPTION
## Summary
- Comprehensive refactoring to make the codebase more idiomatic and cleaner
- Improved error handling with proper error types instead of panics
- More flexible APIs using `impl Into<String>` patterns
- Better documentation and test coverage

## Changes

### Error Handling
- Added `LogoutError` type - logout now returns `Result` instead of panicking on missing token
- Added `DbError` enum for database operations with `Serialization` and `Request` variants
- `insert()` and `update()` now return `Result` to handle serialization errors

### Code Quality
- Removed unnecessary braces in imports (`use reqwest::{Client}` → `use reqwest::Client`)
- Removed redundant type annotations throughout
- Used `#[derive(Clone)]` instead of manual implementation for `Claims`
- Removed `async` from `jwt_valid()` (no await needed)
- Removed debug `println!` statements from production code
- Renamed `Password` struct to `Credentials` for clarity
- Used `&str` in request structs with serde for efficiency
- Added helper method `add_filter()` to reduce code duplication

### API Improvements
- Added `set_bearer_token()` method for cleaner token setting
- Filter methods now accept `impl Into<String>` for flexibility
- `in_()` method now accepts any `IntoIterator` of string-like values

### Modern Rust Patterns
- Used let-else patterns (`let Some(x) = ... else { return }`)
- Used format string interpolation (`{e}` instead of `{}`, e)
- Improved doc comments with proper `///` format

### Tests
- Added `test_client_creation` with explicit values
- Added `test_set_bearer_token`
- Added `test_logout_requires_bearer_token`
- Added `test_db_error_display`
- Increased test count from 15 to 19