### PR TITLE
Add phone auth and OTP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,15 @@
 - [x] Client creation
 - [x] Sign-in email/pass
 - [x] Signup email/pass
-- [ ] Signup phone/pass
+- [x] Signup phone/pass
 - [x] Token refresh
 - [x] Logout
-- [ ] Verify one-time token
+- [x] Verify one-time token
 - [ ] Authorize external OAuth provicder
 - [ ] Password recovery
-- [ ] Resend one-time password over email or SMS
+- [x] Resend one-time password over email or SMS
 - [ ] Magic link authentication
-- [ ] One-time password authentication
+- [x] One-time password authentication
 - [ ] Retrieval of user's information
 - [ ] Reauthentication of a password change
 - [ ] Enrollment of MFA


### PR DESCRIPTION
## Summary
- Add `signup_phone_password`, `sign_in_otp`, `verify_otp`, and `resend_otp` methods to the auth module
- Add corresponding request structs (`PhoneCredentials`, `OtpRequest`, `VerifyOtpRequest`, `ResendOtpRequest`)
- Add tests for all 4 new methods following the existing graceful-skip pattern
- Mark 4 README checklist items as complete: phone signup, verify OTP, OTP authentication, resend OTP

## Test plan
- [x] `cargo build --lib` compiles cleanly
- [x] `cargo test` — all 23 tests pass
- [x] Existing auth and database tests unaffected