### PR TITLE
Add password recovery support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 - [x] Logout
 - [x] Verify one-time token
 - [ ] Authorize external OAuth provicder
-- [ ] Password recovery
+- [x] Password recovery
 - [x] Resend one-time password over email or SMS
 - [ ] Magic link authentication
 - [x] One-time password authentication


### PR DESCRIPTION
## Summary
- Add `recover_password` method that sends a password recovery email via `POST /auth/v1/recover`
- Add `RecoverRequest` struct for the request body
- Add `test_recover_password` test following the existing graceful-skip pattern
- Mark "Password recovery" as complete in the README checklist

## Test plan
- [x] `cargo build --lib` compiles cleanly
- [x] `cargo test` — all 24 tests pass
- [x] Existing tests unaffected