### PR TITLE
Make crate idiomatic, production-ready, and easy to use

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "supabase-rust"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Kacy Fortner <kacy@kacyfortner.com>"]
 edition = "2021"
 description = "Rust client for Supabase"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,14 +7,16 @@ description = "Rust client for Supabase"
 repository = "https://github.com/kacy/supabase-rust.git"
 homepage = "https://github.com/kacy/supabase-rust"
 license = "MIT"
+keywords = ["supabase", "postgrest", "auth", "client"]
+categories = ["api-bindings", "web-programming::http-client"]
 
 [dev-dependencies]
 rand = "0.9"
+tokio = { version = "1", features = ["rt", "macros"] }
 
 [dependencies]
 jsonwebtoken = "9.3"
 reqwest = { version = "0.12", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-time = "0.3.37"
-tokio = { version = "1", features = ["full"] }
+thiserror = "2"

--- a/src/client.rs
+++ b/src/client.rs
@@ -77,19 +77,33 @@ mod tests {
 
     #[test]
     fn test_client_missing_url() {
-        // When no URL is provided and env var is not set, should return Error::Config
+        // Temporarily remove the env var so the constructor can't fall back to it
+        let saved = env::var("SUPABASE_URL").ok();
+        env::remove_var("SUPABASE_URL");
+
         let result = Supabase::new(None, Some("key"), None);
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(matches!(err, crate::Error::Config(_)));
+
+        if let Some(val) = saved {
+            env::set_var("SUPABASE_URL", val);
+        }
     }
 
     #[test]
     fn test_client_missing_api_key() {
+        let saved = env::var("SUPABASE_API_KEY").ok();
+        env::remove_var("SUPABASE_API_KEY");
+
         let result = Supabase::new(Some("https://example.supabase.co"), None, None);
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(matches!(err, crate::Error::Config(_)));
+
+        if let Some(val) = saved {
+            env::set_var("SUPABASE_API_KEY", val);
+        }
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,32 @@
+/// Unified error type for all supabase-rust operations.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// Missing or empty configuration value (URL or API key).
+    #[error("configuration error: {0}")]
+    Config(String),
+
+    /// HTTP transport failure.
+    #[error(transparent)]
+    Request(#[from] reqwest::Error),
+
+    /// JSON serialization or deserialization failure.
+    #[error(transparent)]
+    Serialization(#[from] serde_json::Error),
+
+    /// JWT validation failure.
+    #[error(transparent)]
+    Jwt(#[from] jsonwebtoken::errors::Error),
+
+    /// An authenticated operation was attempted without a bearer token.
+    #[error("authentication required: {0}")]
+    AuthRequired(String),
+
+    /// The Supabase API returned a non-2xx response.
+    #[error("API error {status}: {message}")]
+    Api {
+        /// HTTP status code.
+        status: u16,
+        /// Error message from the response body.
+        message: String,
+    },
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,50 @@
+//! # supabase-rust
+//!
+//! An unofficial Rust client for [Supabase](https://supabase.com).
+//!
+//! Provides typed access to Supabase Auth and PostgREST (database) APIs.
+//!
+//! ## Quick start
+//!
+//! ```rust,no_run
+//! use supabase_rust::{Supabase, AuthResponse, Error};
+//!
+//! # async fn run() -> Result<(), Error> {
+//! let client = Supabase::new(
+//!     Some("https://your-project.supabase.co"),
+//!     Some("your-api-key"),
+//!     None,
+//! )?;
+//!
+//! // Sign in
+//! let auth: AuthResponse = client
+//!     .sign_in_password("user@example.com", "password")
+//!     .await?;
+//! println!("access token: {}", auth.access_token);
+//!
+//! // Query the database
+//! let response = client
+//!     .from("todos")
+//!     .select("*")
+//!     .eq("user_id", &auth.access_token)
+//!     .execute()
+//!     .await?;
+//! # Ok(())
+//! # }
+//! ```
+
 use reqwest::Client;
 
 pub mod auth;
-mod client;
 pub mod db;
+pub mod error;
+mod client;
 
+pub use auth::{AuthResponse, Claims};
+pub use db::QueryBuilder;
+pub use error::Error;
+
+/// The Supabase client. Entry point for all operations.
 #[derive(Clone, Debug)]
 pub struct Supabase {
     client: Client,


### PR DESCRIPTION
## Summary

Bumps version to **0.3.0** with the following changes:

- **Unified error type**: Replace `LogoutError` and `DbError` with a single `thiserror`-derived `Error` enum (`Config`, `Request`, `Serialization`, `Jwt`, `AuthRequired`, `Api`)
- **Fallible constructor**: `Supabase::new()` returns `Result`, validating that `url` and `api_key` are present
- **Typed auth responses**: Auth methods return `AuthResponse` or `EmptyResponse` instead of raw `reqwest::Response`, with automatic non-2xx → `Error::Api` conversion
- **Header deduplication**: Private `auth_post()` helper eliminates repeated header setup across 9 auth methods
- **DB error handling**: `execute()` checks HTTP status and returns `Error::Api` for non-2xx; new `execute_and_parse::<T>()` for automatic JSON deserialization
- **Dependency cleanup**: Remove unused `time`, move `tokio` to dev-deps, add `thiserror = "2"`
- **Ergonomic re-exports**: `Error`, `AuthResponse`, `Claims`, `QueryBuilder` available at crate root
- **Documentation**: Crate-level doc comment with quick start example; crates.io `keywords`/`categories`
- **`#[must_use]`** on `QueryBuilder` to warn if `.execute()` is forgotten
- **Version bump** from 0.2.0 → 0.3.0

### Breaking changes

| Change | Migration |
|--------|-----------|
| `Supabase::new()` returns `Result` | Add `?` or `.unwrap()` |
| Auth methods return `AuthResponse`/`EmptyResponse` | Access fields directly |
| `logout()` returns single `Result` | Remove nested match |
| `DbError` removed | Use `supabase_rust::Error` |
| `LogoutError` removed | Use `Error::AuthRequired` |
| `tokio` moved to dev-deps | Users provide their own async runtime |

## Test plan

- [x] `cargo build --lib` compiles cleanly
- [x] `cargo test` — all 27 tests pass
- [x] `cargo doc --no-deps` — docs generate without warnings